### PR TITLE
Support for SynapseDWH

### DIFF
--- a/DbUpReboot.sln
+++ b/DbUpReboot.sln
@@ -20,6 +20,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{A4038E39-8
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbUp.Reboot.MySql", "source\DbUp.Reboot.MySql\DbUp.Reboot.MySql.csproj", "{7A595528-C313-4A7C-899F-C466CE3CA95D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DbUp.Reboot.SynapseDWH", "source\DbUp.Reboot.SynapseDWH\DbUp.Reboot.SynapseDWH.csproj", "{BCE32C14-27E3-4E0D-BC1F-EC9CCB128F01}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SynapseSampleApplication", "samples\SynapseSampleApplication\SynapseSampleApplication.csproj", "{FD894CD2-4D67-4BD8-8E3C-CDA4BD7A00A1}"
+EndProject
+
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,6 +59,15 @@ Global
 		{7A595528-C313-4A7C-899F-C466CE3CA95D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A595528-C313-4A7C-899F-C466CE3CA95D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A595528-C313-4A7C-899F-C466CE3CA95D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BCE32C14-27E3-4E0D-BC1F-EC9CCB128F01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BCE32C14-27E3-4E0D-BC1F-EC9CCB128F01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BCE32C14-27E3-4E0D-BC1F-EC9CCB128F01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BCE32C14-27E3-4E0D-BC1F-EC9CCB128F01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD894CD2-4D67-4BD8-8E3C-CDA4BD7A00A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD894CD2-4D67-4BD8-8E3C-CDA4BD7A00A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD894CD2-4D67-4BD8-8E3C-CDA4BD7A00A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD894CD2-4D67-4BD8-8E3C-CDA4BD7A00A1}.Release|Any CPU.Build.0 = Release|Any CPU
+
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/SynapseSampleApplication/Program.cs
+++ b/samples/SynapseSampleApplication/Program.cs
@@ -30,9 +30,9 @@ namespace SampleApplication
                     if (script.EndsWith("Script0006 - Transactions.sql"))
                         return !args.Any(a => "--noError".Equals(a, StringComparison.InvariantCultureIgnoreCase));
 
-                    return script.StartsWith("SampleApplication.Scripts.");
+                    return script.StartsWith("SynapseSampleApplication.Scripts.");
                 })
-                .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly(), script => script.StartsWith("SampleApplication.RunAlways."), new SqlScriptOptions { ScriptType = ScriptType.RunAlways, RunGroupOrder = DbUpDefaults.DefaultRunGroupOrder + 1 })
+                .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly(), script => script.StartsWith("SynapseSampleApplication.RunAlways."), new SqlScriptOptions { ScriptType = ScriptType.RunAlways, RunGroupOrder = DbUpDefaults.DefaultRunGroupOrder + 1 })
                 .LogToConsole();
 
             if (args.Any(a => "--withTransaction".Equals(a, StringComparison.InvariantCultureIgnoreCase)))

--- a/samples/SynapseSampleApplication/Program.cs
+++ b/samples/SynapseSampleApplication/Program.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using DbUp.Reboot;
+using DbUp.Reboot.Engine;
+using DbUp.Reboot.Helpers;
+using DbUp.Reboot.Support;
+
+namespace SampleApplication
+{
+    static class Program
+    {
+        public static void Main(string[] args)
+        {
+            var instanceName = @"(localdb)\\MSSQLLocalDB";
+            // Uncomment the following line to run against sql local db instance.
+            // string instanceName = @"(localdb)\Projects";
+
+            var connectionString =
+                $"Server={instanceName}; Database=test8; Trusted_connection=true";
+
+            DropDatabase.For.SynapseDataWarehouse(connectionString);
+
+            EnsureDatabase.For.SynapseDataWarehouse(connectionString);
+
+            var upgradeEngineBuilder = DeployChanges.To
+                .SynapseDataWarehouse(connectionString, null) //null or "" for default schema for user
+                .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly(), script =>
+                {
+                    if (script.EndsWith("Script0006 - Transactions.sql"))
+                        return !args.Any(a => "--noError".Equals(a, StringComparison.InvariantCultureIgnoreCase));
+
+                    return script.StartsWith("SampleApplication.Scripts.");
+                })
+                .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly(), script => script.StartsWith("SampleApplication.RunAlways."), new SqlScriptOptions { ScriptType = ScriptType.RunAlways, RunGroupOrder = DbUpDefaults.DefaultRunGroupOrder + 1 })
+                .LogToConsole();
+
+            if (args.Any(a => "--withTransaction".Equals(a, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                upgradeEngineBuilder = upgradeEngineBuilder.WithTransaction();
+            }
+            else if (args.Any(a => "--withTransactionPerScript".Equals(a, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                upgradeEngineBuilder = upgradeEngineBuilder.WithTransactionPerScript();
+            }
+
+            var upgrader = upgradeEngineBuilder.Build();
+
+            Console.WriteLine("Is upgrade required: " + upgrader.IsUpgradeRequired());
+
+            if (args.Any(a => "--generateReport".Equals(a, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                upgrader.GenerateUpgradeHtmlReport("UpgradeReport.html");
+            }
+            else
+            {
+                var result = upgrader.PerformUpgrade();
+
+                // Display the result
+                if (result.Successful)
+                {
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    Console.WriteLine("Success!");
+                }
+                else
+                {
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine(result.Error);
+                    Console.WriteLine("Failed!");
+                }
+            }
+
+
+            Console.ForegroundColor = ConsoleColor.White;
+            Console.WriteLine();
+            Console.WriteLine("Press any key to delete your database and continue");
+            Console.WriteLine();
+            Console.WriteLine();
+            Console.WriteLine(
+                "Try the --withTransaction or --withTransactionPerScript to see transaction support in action");
+            Console.WriteLine("--noError to exclude the broken script");
+            Console.ReadKey();
+            // Database will be deleted at this point
+        }
+    }
+}

--- a/samples/SynapseSampleApplication/RunAlways/RunAlwaysScript0001 - CreateRole.sql
+++ b/samples/SynapseSampleApplication/RunAlways/RunAlwaysScript0001 - CreateRole.sql
@@ -1,0 +1,4 @@
+﻿IF DATABASE_PRINCIPAL_ID('Testing_Role') IS NULL
+BEGIN
+	CREATE ROLE Testing_Role
+end

--- a/samples/SynapseSampleApplication/Scripts/Script0001 - Create tables.sql
+++ b/samples/SynapseSampleApplication/Scripts/Script0001 - Create tables.sql
@@ -5,10 +5,10 @@
 --  * Revision
 
 create table $schema$.[Entry](
-	[Id] [int] identity(1,1) not null constraint PK_Entry_Id primary key NOT ENFORCED,
+	[Id] [int] identity(1,1) , --not null constraint PK_Entry_Id primary key NOT ENFORCED,
 	[Name] [nvarchar](50) not null,
 	[Title] [nvarchar](200) not null,
-	[Summary] [nvarchar](max) not null,
+	[Summary] [nvarchar](500) not null,
 	[IsVisible] [bit] not null,
 	[Published] [datetime] not null,
 	[LatestRevisionId] [int] null
@@ -16,16 +16,16 @@ create table $schema$.[Entry](
 go
 
 create table $schema$.[Feed](
-	[Id] [int] identity(1,1) not null constraint PK_Feed_Id primary key NOT ENFORCED,
+	[Id] [int] identity(1,1) not null, -- constraint PK_Feed_Id primary key NOT ENFORCED,
 	[Name] [nvarchar](100) not null,
 	[Title] [nvarchar](255) not null,
 )
 go
 
 create table $schema$.[Revision](
-	[Id] [int] identity(1,1) not null constraint PK_Revision_Id primary key NOT ENFORCED,
+	[Id] [int] identity(1,1) not null, -- constraint PK_Revision_Id primary key NOT ENFORCED,
 	[EntryId] [int] not null,
-	[Body] [nvarchar](max) not null,
+	[Body] [nvarchar](500) not null,
 	[ChangeSummary] [nvarchar](1000) not null,
 	[Reason] [nvarchar](1000) not null,
 	[Revised] [datetime] not null,
@@ -37,7 +37,7 @@ create table $schema$.[Revision](
 go
 
 create table $schema$.[FeedItem](
-	[Id] [int] identity(1,1) not null constraint PK_FeedItem_Id primary key NOT ENFORCED,
+	[Id] [int] identity(1,1) not null, -- constraint PK_FeedItem_Id primary key NOT ENFORCED,
 	[FeedId] [int] not null,
 	[ItemId] [int] not null,
 	[SortDate] [datetime] not null,
@@ -45,8 +45,8 @@ create table $schema$.[FeedItem](
 go
 
 create table $schema$.[Comment](
-	[Id] [int] identity(1,1) not null constraint PK_Comment_Id primary key NOT ENFORCED,
-	[Body] [nvarchar](max) not null,
+	[Id] [int] identity(1,1) not null, -- constraint PK_Comment_Id primary key NOT ENFORCED,
+	[Body] [nvarchar](500) not null,
 	[AuthorName] [nvarchar](100) not null,
 	[AuthorCompany] [nvarchar](100) not null,
 	[AuthorEmail] [nvarchar](100) not null,

--- a/samples/SynapseSampleApplication/Scripts/Script0001 - Create tables.sql
+++ b/samples/SynapseSampleApplication/Scripts/Script0001 - Create tables.sql
@@ -1,0 +1,58 @@
+﻿-- Creates the following tables:
+--  * Entry
+--  * Feed
+--  * FeedItem
+--  * Revision
+
+create table $schema$.[Entry](
+	[Id] [int] identity(1,1) not null constraint PK_Entry_Id primary key NOT ENFORCED,
+	[Name] [nvarchar](50) not null,
+	[Title] [nvarchar](200) not null,
+	[Summary] [nvarchar](max) not null,
+	[IsVisible] [bit] not null,
+	[Published] [datetime] not null,
+	[LatestRevisionId] [int] null
+)
+go
+
+create table $schema$.[Feed](
+	[Id] [int] identity(1,1) not null constraint PK_Feed_Id primary key NOT ENFORCED,
+	[Name] [nvarchar](100) not null,
+	[Title] [nvarchar](255) not null,
+)
+go
+
+create table $schema$.[Revision](
+	[Id] [int] identity(1,1) not null constraint PK_Revision_Id primary key NOT ENFORCED,
+	[EntryId] [int] not null,
+	[Body] [nvarchar](max) not null,
+	[ChangeSummary] [nvarchar](1000) not null,
+	[Reason] [nvarchar](1000) not null,
+	[Revised] [datetime] not null,
+	[Tags] [nvarchar](1000) not null,
+	[Status] [int] not null,
+	[IsVisible] [bit] not null,
+	[RevisionNumber] [int] not null,
+)
+go
+
+create table $schema$.[FeedItem](
+	[Id] [int] identity(1,1) not null constraint PK_FeedItem_Id primary key NOT ENFORCED,
+	[FeedId] [int] not null,
+	[ItemId] [int] not null,
+	[SortDate] [datetime] not null,
+)
+go
+
+create table $schema$.[Comment](
+	[Id] [int] identity(1,1) not null constraint PK_Comment_Id primary key NOT ENFORCED,
+	[Body] [nvarchar](max) not null,
+	[AuthorName] [nvarchar](100) not null,
+	[AuthorCompany] [nvarchar](100) not null,
+	[AuthorEmail] [nvarchar](100) not null,
+	[AuthorUrl] [nvarchar](100) not null,
+	[Posted] [datetime] not null,
+	[EntryId] [int] not null,
+	[Status] int not null
+)
+go

--- a/samples/SynapseSampleApplication/Scripts/Script0002 - Default feed.sql
+++ b/samples/SynapseSampleApplication/Scripts/Script0002 - Default feed.sql
@@ -1,0 +1,3 @@
+﻿-- Initial setup data
+
+insert into $schema$.Feed([Name], [Title]) values ('default', 'Blog Feed');

--- a/samples/SynapseSampleApplication/Scripts/Script0003 - Settings.sql
+++ b/samples/SynapseSampleApplication/Scripts/Script0003 - Settings.sql
@@ -1,0 +1,18 @@
+﻿-- Settings and Statistics
+
+create table $schema$.Setting(
+    [Id] [int] identity(1,1) not null constraint PK_Setting_Id primary key NOT ENFORCED,
+	[Name] [nvarchar](50) not null,
+	[Description] [nvarchar](max) not null,
+	[DisplayName] [nvarchar](200) not null,
+	[Value] [nvarchar](max) not null
+)
+go
+
+insert into $schema$.Setting([Name], DisplayName, Value, Description) values ('ui-title', 'Title', 'My FunnelWeb Site', 'Text: The title shown at the top in the browser.');
+insert into $schema$.Setting([Name], DisplayName, Value, Description) values ('ui-introduction', 'Introduction', 'Welcome to your FunnelWeb blog. You can <a href="/login">login</a> and edit this message in the administration section. The default username and password is <code>test/test</code>.', 'Markdown: The introductory text that is shown on the home page.');
+insert into $schema$.Setting([Name], DisplayName, Value, Description) values ('ui-links', 'Main Links', '<li><a href="/projects">Projects</a></li>', 'HTML: A list of links shown at the top of each page.');
+
+insert into $schema$.Setting([Name], DisplayName, Value, Description) values ('search-author', 'Author', 'Daffy Duck', 'Text: Your name.');
+insert into $schema$.Setting([Name], DisplayName, Value, Description) values ('search-keywords', 'Keywords', '.net, c#, test', 'Comma-separated text: Keywords shown to search engines.');
+insert into $schema$.Setting([Name], DisplayName, Value, Description) values ('search-description', 'Description', 'My website.', 'Text: The description shown to search engines in the meta description tag.');

--- a/samples/SynapseSampleApplication/Scripts/Script0003 - Settings.sql
+++ b/samples/SynapseSampleApplication/Scripts/Script0003 - Settings.sql
@@ -1,11 +1,11 @@
 ﻿-- Settings and Statistics
 
 create table $schema$.Setting(
-    [Id] [int] identity(1,1) not null constraint PK_Setting_Id primary key NOT ENFORCED,
+    [Id] [int] identity(1,1), -- not null constraint PK_Setting_Id primary key NOT ENFORCED,
 	[Name] [nvarchar](50) not null,
-	[Description] [nvarchar](max) not null,
+	[Description] [nvarchar](200) not null,
 	[DisplayName] [nvarchar](200) not null,
-	[Value] [nvarchar](max) not null
+	[Value] [nvarchar](200) not null
 )
 go
 

--- a/samples/SynapseSampleApplication/Scripts/Script0004 - Redirects.sql
+++ b/samples/SynapseSampleApplication/Scripts/Script0004 - Redirects.sql
@@ -1,7 +1,7 @@
 ﻿-- Settings and Statistics
 
 create table $schema$.Redirect(
-    [Id] [int] identity(1,1) not null constraint PK_Redirect_Id primary key NOT ENFORCED,
+    [Id] [int] identity(1,1) not null, -- constraint PK_Redirect_Id primary key NOT ENFORCED,
 	[From] [nvarchar](255) not null,
 	[To] [nvarchar](255) not null
 )

--- a/samples/SynapseSampleApplication/Scripts/Script0004 - Redirects.sql
+++ b/samples/SynapseSampleApplication/Scripts/Script0004 - Redirects.sql
@@ -1,0 +1,9 @@
+﻿-- Settings and Statistics
+
+create table $schema$.Redirect(
+    [Id] [int] identity(1,1) not null constraint PK_Redirect_Id primary key NOT ENFORCED,
+	[From] [nvarchar](255) not null,
+	[To] [nvarchar](255) not null
+)
+go
+

--- a/samples/SynapseSampleApplication/Scripts/Script0005 - ComplexUpdate.cs
+++ b/samples/SynapseSampleApplication/Scripts/Script0005 - ComplexUpdate.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Data;
+using DbUp.Reboot.Engine;
+
+namespace SampleApplication.Scripts
+{
+    public class Script0005ComplexUpdate : IScript
+    {
+        public string ProvideScript(Func<IDbCommand> commandFactory)
+        {
+            // If you have something that requires logic to update, it is sometimes easier doing that in code rather than sql.
+            // By creating a code script, you get an open connection and you can build the sql script on the fly at the time of execution
+            // 
+            // The ProvideScript method will be called when it is THIS scripts turn to be executed, so the scripts before have already been executed
+
+            // Example
+            //var cmd = sqlConnectionString.CreateCommand();
+            //cmd.CommandText = "Select * from SomeTable";
+            //var scriptBuilder = new StringBuilder();
+
+            //using (var reader = cmd.ExecuteReader())
+            //{
+            //    while (reader.Read())
+            //    {
+            //        scriptBuilder.AppendLine(string.Format("insert into AnotherTable values ({0})", reader.GetString(0)));
+            //    }
+            //}
+
+            //return scriptBuilder;
+
+            return "select 1";
+        }
+    }
+}

--- a/samples/SynapseSampleApplication/Scripts/Script0006 - Transactions.sql
+++ b/samples/SynapseSampleApplication/Scripts/Script0006 - Transactions.sql
@@ -1,0 +1,8 @@
+﻿-- Settings and Statistics
+create table $schema$.Foo(
+	[Id] [int] identity(1,1) not null primary key NOT ENFORCED,
+	[Name] [nvarchar](50) not null
+)
+go
+
+insert into $schema$.[Entry] values()

--- a/samples/SynapseSampleApplication/Scripts/Script0006 - Transactions.sql
+++ b/samples/SynapseSampleApplication/Scripts/Script0006 - Transactions.sql
@@ -1,6 +1,6 @@
 ﻿-- Settings and Statistics
 create table $schema$.Foo(
-	[Id] [int] identity(1,1) not null primary key NOT ENFORCED,
+	[Id] [int] identity(1,1) not null, -- primary key NOT ENFORCED,
 	[Name] [nvarchar](50) not null
 )
 go

--- a/samples/SynapseSampleApplication/SynapseSampleApplication.csproj
+++ b/samples/SynapseSampleApplication/SynapseSampleApplication.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>SynapseSampleApplication</RootNamespace>
+    <AssemblyName>SynapseSampleApplication</AssemblyName> 
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Scripts\*.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="RunAlways\RunAlwaysScript0001 - CreateRole.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="RunAlways\RunAlwaysScript0001 - CreateRole.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\source\DbUp.Reboot.SynapseDWH\DbUp.Reboot.SynapseDWh.csproj" />
+  </ItemGroup>
+</Project>

--- a/source/DbUp.Reboot.SynapseDWH/DbUp.Reboot.SynapseDWH.csproj
+++ b/source/DbUp.Reboot.SynapseDWH/DbUp.Reboot.SynapseDWH.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>DbUp Reboot is a fork of the DbUp project that focuses on modern technologies and development approaches.
+
+DbUp Reboot makes it easy to deploy and upgrade SQL Server databases. This package adds SynapseDWH support.</Description>
+    <Title>DbUp SynapseDWH Support</Title>
+    <Authors>DbUp Reboot Contributors</Authors>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>DbUp.Reboot.SynapseDWH</AssemblyName>
+    <PackageId>DbUp.Reboot.SynapseDWH</PackageId>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Copyright>Copyright © DbUp Reboot Contributors 2021; portions copyright  DbUp Contributors 2015</Copyright>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <PackageProjectUrl>https://github.com/chriswill/DbUpReboot</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/chriswill/DbUpReboot</RepositoryUrl>
+    <PackageTags>DbUp Reboot database SynapseDWH</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
+</ItemGroup>
+
+<ItemGroup>
+  <ProjectReference Include="..\DbUp.Reboot.Core\DbUp.Reboot.Core.csproj" />
+</ItemGroup>
+
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE.md">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/source/DbUp.Reboot.SynapseDWH/SynapseDwConnectionManager.cs
+++ b/source/DbUp.Reboot.SynapseDWH/SynapseDwConnectionManager.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.SqlClient;
+using DbUp.Reboot.Engine.Transactions;
+using DbUp.Reboot.Support;
+
+namespace DbUp.Reboot.SynapseDataWarehouse
+{
+    /// <summary>
+    /// Manages Azure SQL Date Warehouse Database Connections
+    /// </summary>
+    public class SynapseDwConnectionManager : DatabaseConnectionManager
+    {
+        /// <summary>
+        /// Manages Azure SQL Date Warehouse Database Connections
+        /// </summary>
+        /// <param name="connectionString"></param>
+        public SynapseDwConnectionManager(string connectionString)
+            : base(new DelegateConnectionFactory((log, dbManager) =>
+            {
+                var conn = new SqlConnection(connectionString);
+
+                if (dbManager.IsScriptOutputLogged)
+                    conn.InfoMessage += (sender, e) => log.WriteInformation("{0}\r\n", e.Message);
+
+                return conn;
+            }))
+        {
+        }
+
+        public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
+        {
+            var commandSplitter = new SqlCommandSplitter();
+            var scriptStatements = commandSplitter.SplitScriptIntoCommands(scriptContents);
+            return scriptStatements;
+        }
+    }
+}

--- a/source/DbUp.Reboot.SynapseDWH/SynapseDwScriptExecutor.cs
+++ b/source/DbUp.Reboot.SynapseDWH/SynapseDwScriptExecutor.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.SqlClient;
+using DbUp.Reboot.Engine;
+using DbUp.Reboot.Engine.Output;
+using DbUp.Reboot.Engine.Transactions;
+using DbUp.Reboot.Support;
+
+namespace DbUp.Reboot.SynapseDataWarehouse
+{
+    /// <summary>
+    /// An implementation of ScriptExecutor that executes against an Azure SQL Data Warehouse database.
+    /// </summary>
+    public class SynapseDwScriptExecutor : ScriptExecutor
+    {
+        /// <summary>
+        /// Initializes an instance of the <see cref="SqlScriptExecutor"/> class.
+        /// </summary>
+        /// <param name="connectionManagerFactory"></param>
+        /// <param name="log">The logging mechanism.</param>
+        /// <param name="schema">The schema that contains the table.</param>
+        /// <param name="variablesEnabled">Function that returns <c>true</c> if variables should be replaced, <c>false</c> otherwise.</param>
+        /// <param name="scriptPreprocessors">Script Preprocessors in addition to variable substitution</param>
+        /// <param name="journalFactory">Database journal</param>
+        public SynapseDwScriptExecutor(Func<IConnectionManager> connectionManagerFactory, Func<IUpgradeLog> log, string schema, Func<bool> variablesEnabled,
+            IEnumerable<IScriptPreprocessor> scriptPreprocessors, Func<IJournal> journalFactory)
+            : base(connectionManagerFactory, new SynapseDwServerObjectParser(), log, schema, variablesEnabled, scriptPreprocessors, journalFactory)
+        {
+
+        }
+
+        protected override string GetVerifySchemaSql(string schema)
+        {
+            return string.Format(@"IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = N'{0}') Exec('CREATE SCHEMA [{0}]')", Schema);
+        }      
+
+        protected override void ExecuteCommandsWithinExceptionHandler(int index, SqlScript script, Action excuteCommand)
+        {
+            try
+            {
+                excuteCommand();
+            }
+            catch (SqlException sqlException)
+            {
+                Log().WriteInformation("SQL exception has occurred in script: '{0}'", script.Name);
+                Log().WriteError("Script block number: {0}; Block line {1}; Message: {2}", index, sqlException.LineNumber, sqlException.Procedure, sqlException.Number, sqlException.Message);
+                Log().WriteError(sqlException.ToString());
+                throw;
+            }
+        }
+
+    }
+}

--- a/source/DbUp.Reboot.SynapseDWH/SynapseDwServerExtensions.cs
+++ b/source/DbUp.Reboot.SynapseDWH/SynapseDwServerExtensions.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Data;
+using Microsoft.Data.SqlClient;
+using DbUp.Reboot;
+using DbUp.Reboot.Builder;
+using DbUp.Reboot.Engine.Output;
+using DbUp.Reboot.Engine.Transactions;
+using DbUp.Reboot.SynapseDataWarehouse;
+
+/// <summary>
+/// Configuration extension methods for Azure SQL Data Warehouse.
+/// </summary>
+// NOTE: DO NOT MOVE THIS TO A NAMESPACE
+// Since the class just contains extension methods, we leave it in the global:: namespace so that it is always available
+// ReSharper disable CheckNamespace
+public static class SynapseDwServerExtensions
+// ReSharper restore CheckNamespace
+{
+    /// <summary>
+    /// Creates an upgrader for Azure SQL Data Warehouse databases.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <returns>
+    /// A builder for a database upgrader designed for Azure SQL Data Warehouse databases.
+    /// </returns>
+    public static UpgradeEngineBuilder SynapseDataWarehouse(this SupportedDatabases supported, string connectionString)
+    {
+        return SynapseDataWarehouse(supported, connectionString, null);
+    }
+
+    /// <summary>
+    /// Creates an upgrader for Azure SQL Data Warehouse databases.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo'.</param>
+    /// <returns>
+    /// A builder for a database upgrader designed for Azure SQL Data Warehouse databases.
+    /// </returns>
+    public static UpgradeEngineBuilder SynapseDataWarehouse(this SupportedDatabases supported, string connectionString, string schema)
+    {
+        return SynapseDataWarehouse(new DbUp.Reboot.SynapseDataWarehouse.SynapseDwConnectionManager(connectionString), schema);
+    }
+
+    /// <summary>
+    /// Creates an upgrader for Azure SQL Data Warehouse databases.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionManager">The <see cref="IConnectionManager"/> to be used during a database
+    /// upgrade. See <see cref="SqlConnectionManager"/> for an example implementation</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo'.</param>
+    /// <returns>
+    /// A builder for a database upgrader designed for Azure SQL Data Warehouse databases.
+    /// </returns>
+    public static UpgradeEngineBuilder SynapseDataWarehouse(this SupportedDatabases supported, IConnectionManager connectionManager, string schema = null)
+        => SynapseDataWarehouse(connectionManager, schema);
+
+    /// <summary>
+    /// Creates an upgrader for Azure SQL Data Warehouse databases.
+    /// </summary>
+    /// <param name="connectionManager">The <see cref="IConnectionManager"/> to be used during a database
+    /// upgrade. See <see cref="SqlConnectionManager"/> for an example implementation</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo'.</param>
+    /// <returns>
+    /// A builder for a database upgrader designed for Azure SQL Data Warehouse databases.
+    /// </returns>
+    private static UpgradeEngineBuilder SynapseDataWarehouse(IConnectionManager connectionManager, string schema)
+    {
+        var builder = new UpgradeEngineBuilder();
+        builder.Configure(c => c.ConnectionManager = connectionManager);
+        builder.Configure(c => c.ScriptExecutor = new SynapseDwScriptExecutor(() => c.ConnectionManager, () => c.Log, schema, () => c.VariablesEnabled, c.ScriptPreprocessors, () => c.Journal));
+        builder.Configure(c => c.Journal = new SynapseDwTableJournal(() => c.ConnectionManager, () => c.Log, schema, "SchemaVersions"));
+        return builder;
+    }
+
+    /// <summary>
+    /// Tracks the list of executed scripts in an Azure SQL Data Warehouse table.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="schema">The schema.</param>
+    /// <param name="table">The table.</param>
+    /// <returns></returns>
+    public static UpgradeEngineBuilder JournalToSynapseDwTable(this UpgradeEngineBuilder builder, string schema, string table)
+    {
+        builder.Configure(c => c.Journal = new SynapseDwTableJournal(() => c.ConnectionManager, () => c.Log, schema, table));
+        return builder;
+    }
+
+    /// <summary>
+    /// Ensures that the database specified in the connection string exists.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <returns></returns>
+    public static void SynapseDataWarehouse(this SupportedDatabasesForEnsureDatabase supported, string connectionString)
+    {
+        SynapseDataWarehouse(supported, connectionString, new ConsoleUpgradeLog());
+    }
+
+    /// <summary>
+    /// Ensures that the database specified in the connection string exists.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="commandTimeout">Use this to set the command time out for creating a database in case you're encountering a time out in this operation.</param>
+    /// <returns></returns>
+    public static void SynapseDataWarehouse(this SupportedDatabasesForEnsureDatabase supported, string connectionString, int commandTimeout)
+    {
+        SynapseDataWarehouse(supported, connectionString, new ConsoleUpgradeLog(), commandTimeout);
+    }
+
+    /// <summary>
+    /// Ensures that the database specified in the connection string exists.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="logger">The <see cref="DbUp.Engine.Output.IUpgradeLog"/> used to record actions.</param>
+    /// <param name="timeout">Use this to set the command time out for creating a database in case you're encountering a time out in this operation.</param>
+    /// <returns></returns>
+    public static void SynapseDataWarehouse(this SupportedDatabasesForEnsureDatabase supported, string connectionString, IUpgradeLog logger, int timeout = -1)
+    {
+        string databaseName;
+        string masterConnectionString;
+        GetMasterConnectionStringBuilder(connectionString, logger, out masterConnectionString, out databaseName);
+
+        using (var connection = new SqlConnection(masterConnectionString))
+        {
+            connection.Open();
+
+            var sqlCommandText = string.Format
+                (
+                    @"SELECT TOP 1 case WHEN dbid IS NOT NULL THEN 1 ELSE 0 end FROM sys.sysdatabases WHERE name = '{0}';",
+                    databaseName
+                );
+
+
+            // check to see if the database already exists..
+            using (var command = new SqlCommand(sqlCommandText, connection)
+            {
+                CommandType = CommandType.Text
+            })
+
+            {
+                var results = (int?)command.ExecuteScalar();
+
+                // if the database exists, we're done here...
+                if (results.HasValue && results.Value == 1)
+                {
+                    return;
+                }
+            }
+
+            var parser = new SynapseDwServerObjectParser();
+            databaseName = parser.QuoteIdentifier(databaseName);
+
+            sqlCommandText = $"CREATE DATABASE {databaseName} (EDITION = 'DataWarehouse', SERVICE_OBJECTIVE = 'DW100', MAXSIZE = 250 GB);";
+
+            // Create the database...
+            using (var command = new SqlCommand(sqlCommandText, connection)
+            {
+                CommandType = CommandType.Text
+            })
+            {
+                if (timeout >= 0)
+                {
+                    command.CommandTimeout = timeout;
+                }
+
+                command.ExecuteNonQuery();
+
+            }
+
+            logger.WriteInformation(@"Created database {0}", databaseName);
+        }
+    }
+
+    /// <summary>
+    /// Drop the database specified in the connection string.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <returns></returns>
+    public static void SynapseDataWarehouse(this SupportedDatabasesForDropDatabase supported, string connectionString)
+    {
+        SynapseDataWarehouse(supported, connectionString, new ConsoleUpgradeLog());
+    }
+
+    /// <summary>
+    /// Drop the database specified in the connection string.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="commandTimeout">Use this to set the command time out for dropping a database in case you're encountering a time out in this operation.</param>
+    /// <returns></returns>
+    public static void SynapseDataWarehouse(this SupportedDatabasesForDropDatabase supported, string connectionString, int commandTimeout)
+    {
+        SynapseDataWarehouse(supported, connectionString, new ConsoleUpgradeLog(), commandTimeout);
+    }
+
+    /// <summary>
+    /// Drop the database specified in the connection string.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="logger">The <see cref="DbUp.Engine.Output.IUpgradeLog"/> used to record actions.</param>
+    /// <param name="timeout">Use this to set the command time out for dropping a database in case you're encountering a time out in this operation.</param>
+    /// <returns></returns>
+    public static void SynapseDataWarehouse(this SupportedDatabasesForDropDatabase supported, string connectionString, IUpgradeLog logger, int timeout = -1)
+    {
+        string databaseName;
+        string masterConnectionString;
+        GetMasterConnectionStringBuilder(connectionString, logger, out masterConnectionString, out databaseName);
+
+        using (var connection = new SqlConnection(masterConnectionString))
+        {
+            connection.Open();
+            var databaseExistCommand = new SqlCommand($"SELECT TOP 1 case WHEN dbid IS NOT NULL THEN 1 ELSE 0 end FROM sys.sysdatabases WHERE name = '{databaseName}';", connection)
+            {
+                CommandType = CommandType.Text
+            };
+            using (var command = databaseExistCommand)
+            {
+                var exists = (int?)command.ExecuteScalar();
+                if (!exists.HasValue)
+                    return;
+            }
+
+            var parser = new SynapseDwServerObjectParser();
+            databaseName = parser.QuoteIdentifier(databaseName);
+
+            var dropDatabaseCommand = new SqlCommand($"ALTER DATABASE {databaseName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE {databaseName};", connection) { CommandType = CommandType.Text };
+            using (var command = dropDatabaseCommand)
+            {
+                command.ExecuteNonQuery();
+            }
+
+            logger.WriteInformation("Dropped database {0}", databaseName);
+        }
+    }
+
+    private static void GetMasterConnectionStringBuilder(string connectionString, IUpgradeLog logger, out string masterConnectionString, out string databaseName)
+    {
+        if (string.IsNullOrEmpty(connectionString) || connectionString.Trim() == string.Empty)
+            throw new ArgumentNullException("connectionString");
+
+        if (logger == null)
+            throw new ArgumentNullException("logger");
+
+        var masterConnectionStringBuilder = new SqlConnectionStringBuilder(connectionString);
+        databaseName = masterConnectionStringBuilder.InitialCatalog;
+
+        if (string.IsNullOrEmpty(databaseName) || databaseName.Trim() == string.Empty)
+            throw new InvalidOperationException("The connection string does not specify a database name.");
+
+        masterConnectionStringBuilder.InitialCatalog = "master";
+        var logMasterConnectionStringBuilder = new SqlConnectionStringBuilder(masterConnectionStringBuilder.ConnectionString)
+        {
+            Password = string.Empty.PadRight(masterConnectionStringBuilder.Password.Length, '*')
+        };
+
+        logger.WriteInformation("Master ConnectionString => {0}", logMasterConnectionStringBuilder.ConnectionString);
+        masterConnectionString = masterConnectionStringBuilder.ConnectionString;
+    }
+}

--- a/source/DbUp.Reboot.SynapseDWH/SynapseDwServerObjectParser.cs
+++ b/source/DbUp.Reboot.SynapseDWH/SynapseDwServerObjectParser.cs
@@ -1,0 +1,51 @@
+using DbUp.Reboot.Support;
+using System;
+using Microsoft.Data.SqlClient;
+using System.Linq;
+
+namespace DbUp.Reboot.SynapseDataWarehouse
+{
+    /// <summary>
+    /// Parses Sql Objects and performs quoting functions
+    /// </summary>
+    public class SynapseDwServerObjectParser : DbUp.Reboot.Support.SqlObjectParser
+    {
+
+        public SynapseDwServerObjectParser() : base("[", "]")
+        {
+
+        }
+
+        /// <summary>
+        /// Quotes the SQL identifier to allow Special characters in the object name.
+        /// This function implements System.Data.SqlClient.SqlCommandBuilder.QuoteIdentifier() with an additional
+        /// validation which is missing from the SqlCommandBuilder version.
+        /// </summary>
+        /// <param name="objectName">Name of the object to quote.</param>
+        /// <param name="objectNameOptions">The settings which indicate if the whitespace should be dropped or not.</param>
+        /// <returns>The quoted object name</returns>
+        public override string QuoteIdentifier(string objectName, ObjectNameOptions objectNameOptions)
+        {
+            if (string.IsNullOrEmpty(objectName))
+                throw new ArgumentNullException();
+
+
+            if (ObjectNameOptions.Trim == objectNameOptions)
+                objectName = objectName.Trim();
+
+
+            const int SqlSysnameLength = 128;
+            if (objectName.Length > SqlSysnameLength)
+                throw new ArgumentOutOfRangeException(@"objectName", "An Azure SQL Data Warehouse object name is maximum 128 characters long");
+
+
+            // The ] in the string need to be doubled up so it means we always need an un-even number of ] 
+            if (objectName.StartsWith("[") && objectName.EndsWith("]") && objectName.Count(x => x == ']') % 2 == 1)
+                return objectName;
+
+
+            return string.Concat("[", objectName.Replace("]", "]]"), "]");
+
+        }
+    }
+}

--- a/source/DbUp.Reboot.SynapseDWH/SynapseDwTableJournal.cs
+++ b/source/DbUp.Reboot.SynapseDWH/SynapseDwTableJournal.cs
@@ -1,0 +1,53 @@
+using System;
+using DbUp.Reboot.Engine.Output;
+using DbUp.Reboot.Engine.Transactions;
+using DbUp.Reboot.Support;
+
+namespace DbUp.Reboot.SynapseDataWarehouse
+{
+    /// <summary>
+    /// An implementation of the <see cref="Engine.IJournal"/> interface which tracks version numbers for an 
+    /// Azure SQL Data Warehouse database using a table called dbo.SchemaVersions.
+    /// </summary>
+    public class SynapseDwTableJournal : TableJournal
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlTableJournal"/> class.
+        /// </summary>
+        /// <param name="connectionManager">The connection manager.</param>
+        /// <param name="logger">The log.</param>
+        /// <param name="schema">The schema that contains the table.</param>
+        /// <param name="table">The table name.</param>
+        /// <example>
+        /// var journal = new TableJournal("Server=server;Database=database;Trusted_Connection=True", "dbo", "MyVersionTable");
+        /// </example>
+        public SynapseDwTableJournal(Func<IConnectionManager> connectionManager, Func<IUpgradeLog> logger, string schema, string table)
+            : base(connectionManager, logger, new SynapseDwServerObjectParser(), schema, table)
+        {
+        }
+
+        protected override string GetInsertJournalEntrySql(string @scriptName, string @applied)
+        {
+            return $"insert into {FqSchemaTableName} (ScriptName, Applied) values ({@scriptName}, {@applied})";
+        }
+
+        protected override string GetJournalEntriesSql()
+        {
+            return $"select [ScriptName] from {FqSchemaTableName} order by [ScriptName]";
+        }
+
+        protected override string CreateSchemaTableSql(string quotedPrimaryKeyName)
+        {
+            return 
+$@"create table {FqSchemaTableName} (
+    [Id] int identity(1,1) not null,
+    [ScriptName] nvarchar(255) not null,
+    [Applied] datetime not null
+)
+WITH (   
+    distribution = round_robin,
+    clustered index ([Id])
+)";
+        }
+    }
+}


### PR DESCRIPTION
This is a port of https://github.com/DbUp/DbUp/pull/253 which adds support for Azure SQL Datawarehouse, now labeled SynapseDWH.
Key points:
1. PK and FK constraints are not supported by Synapse. Hence Journal Table does not define PK. 
2. SynapseSampleApplication follows the same sample entities as SampleApplication; applied the deletion of PK, and FK which are not supported.
3. Solution (.sln) file has been updated to include support for SynapseDWH
